### PR TITLE
Dev

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,30 @@
 
+// var reuslt1 = NearestExitFromEntranceInMaze.NearestExit([['+', '+', '.', '+'], ['.', '.', '.', '+'], ['+', '+', '+', '.']], [1, 2]);
 
-var result = FindCenterOfStarGraph.FindCenter([[1, 2], [2, 3], [4, 2]]);
-Console.WriteLine(result);
+// Console.WriteLine(reuslt1);
+
+
+
+// var reuslt2 = NearestExitFromEntranceInMaze.NearestExit([['+', '+', '+'], ['.', '.', '.'], ['+', '+', '+']], [1, 0]);
+
+// Console.WriteLine(reuslt2);
+
+// var reuslt3 = NearestExitFromEntranceInMaze.NearestExit([['.','+','+','+','+'],
+//                                                          ['.','+','.','.','.'],
+//                                                          ['.','+','.','+','.'],
+//                                                          ['.','.','.','+','.'],
+//                                                          ['+','+','+','+','.']],
+//                                                          [0, 0]);
+
+// Console.WriteLine(reuslt3);
+
+
+
+var reuslt4 = NearestExitFromEntranceInMaze.NearestExit([[ '+', '.', '+', '+', '+', '+', '+' ],
+                                                         [ '+', '.', '+', '.', '.', '.', '+' ],
+                                                         [ '+', '.', '+', '.', '+', '.', '+' ],
+                                                         [ '+', '.', '.', '.', '.', '.', '+' ],
+                                                         ['+', '+', '+', '+', '.', '+', '.' ]],
+                                                         [0, 1]);
+
+Console.WriteLine(reuslt4);

--- a/solutions/NearestExitFromEntranceInMaze.cs
+++ b/solutions/NearestExitFromEntranceInMaze.cs
@@ -4,8 +4,8 @@ public sealed class NearestExitFromEntranceInMaze
     {
         Queue<(int x, int y, int step)> queue = new();
 
-        int m = maze.Length; ; // satır/line
-        int n = maze[0].Length; // sütun/column
+        int m = maze.Length;
+        int n = maze[0].Length;
 
 
         bool[,] visited = new bool[m, n];
@@ -24,10 +24,8 @@ public sealed class NearestExitFromEntranceInMaze
             // should be empty and at the border
             // and it shouldn't at the step zero "0"
 
-            if (current.step != 0 && maze[current.y][current.x] == '.' && (current.x == n - 1 || current.x == 0))
-                return current.step;
-
-            if (current.step != 0 && maze[current.y][current.x] == '.' && (current.y == 0 || current.y == m - 1))
+            if (current.step != 0 && maze[current.y][current.x] == '.' &&
+                (current.x == n - 1 || current.x == 0 || current.y == 0 || current.y == m - 1))
                 return current.step;
 
             // up = y - 1;
@@ -48,6 +46,50 @@ public sealed class NearestExitFromEntranceInMaze
 
         }
 
+        return -1;
+    }
+
+
+    public static int NearestExitRefactored(char[][] maze, int[] entrance)
+    {
+        Queue<(int x, int y, int step)> queue = new();
+        int m = maze.Length;
+        int n = maze[0].Length;
+        bool[,] visited = new bool[m, n];
+
+        int startRow = entrance[0];
+        int startCol = entrance[1];
+
+        queue.Enqueue((startCol, startRow, 0));
+
+        visited[startRow, startCol] = true;
+
+        int[][] directions = { new int[] { 0, 1 }, new int[] { 0, -1 }, new int[] { 1, 0 }, new int[] { -1, 0 } };
+
+        while (queue.Count > 0)
+        {
+            (int x, int y, int step) current = queue.Dequeue();
+
+            bool isAtBorder = current.x == 0 || current.x == n - 1 || current.y == 0 || current.y == m - 1;
+            bool isStartCell = current.y == startRow && current.x == startCol;
+
+            if (isAtBorder && !isStartCell)
+                return current.step;
+
+
+            foreach (var dir in directions)
+            {
+                int nextY = current.y + dir[0];
+                int nextX = current.x + dir[1];
+
+                if (nextY >= 0 && nextY < m && nextX >= 0 && nextX < n &&
+                    maze[nextY][nextX] == '.' && !visited[nextY, nextX])
+                {
+                    visited[nextY, nextX] = true;
+                    queue.Enqueue((nextX, nextY, current.step + 1));
+                }
+            }
+        }
         return -1;
     }
 

--- a/solutions/NearestExitFromEntranceInMaze.cs
+++ b/solutions/NearestExitFromEntranceInMaze.cs
@@ -1,0 +1,54 @@
+public sealed class NearestExitFromEntranceInMaze
+{
+    public static int NearestExit(char[][] maze, int[] entrance)
+    {
+        Queue<(int x, int y, int step)> queue = new();
+
+        int m = maze.Length; ; // satır/line
+        int n = maze[0].Length; // sütun/column
+
+
+        bool[,] visited = new bool[m, n];
+
+        queue.Enqueue((x: entrance[1], y: entrance[0], 0));
+
+        while (queue.Count > 0)
+        {
+            var current = queue.Dequeue();
+
+            if (visited[current.y, current.x]) continue;
+
+            visited[current.y, current.x] = true;
+
+            // is it an exit point
+            // should be empty and at the border
+            // and it shouldn't at the step zero "0"
+
+            if (current.step != 0 && maze[current.y][current.x] == '.' && (current.x == n - 1 || current.x == 0))
+                return current.step;
+
+            if (current.step != 0 && maze[current.y][current.x] == '.' && (current.y == 0 || current.y == m - 1))
+                return current.step;
+
+            // up = y - 1;
+            if (current.y - 1 >= 0 && maze[current.y - 1][current.x] == '.')
+                queue.Enqueue((current.x, current.y - 1, current.step + 1));
+
+            // left = x - 1
+            if (current.x - 1 >= 0 && maze[current.y][current.x - 1] == '.')
+                queue.Enqueue((current.x - 1, current.y, current.step + 1));
+
+            // down = y + 1
+            if (current.y + 1 <= m - 1 && maze[current.y + 1][current.x] == '.')
+                queue.Enqueue((current.x, current.y + 1, current.step + 1));
+
+            // right = x + 1
+            if (current.x + 1 <= n - 1 && maze[current.y][current.x + 1] == '.')
+                queue.Enqueue((current.x + 1, current.y, current.step + 1));
+
+        }
+
+        return -1;
+    }
+
+}

--- a/solutions/RottingOranges.cs
+++ b/solutions/RottingOranges.cs
@@ -1,0 +1,89 @@
+using System;
+
+namespace LeetCode75.solutions;
+
+// 994. Rotting Oranges
+// https://leetcode.com/problems/rotting-oranges/description/?envType=study-plan-v2&envId=leetcode-75
+public class RottingOranges
+{
+    // 0 representing an empty cell,
+    // 1 representing a fresh orange, or
+    // 2 representing a rotten orange.
+
+    // Constraints:
+    // m == grid.length
+    // n == grid[i].length
+    // 1 <= m, n <= 10
+    // grid[i][j] is 0, 1, or 2.
+
+    // Every minute, any fresh orange that is 4-directionally adjacent to a rotten orange becomes rotten.
+    // Return the minimum number of minutes that must elapse until no cell has a fresh orange. If this is impossible, return -1.
+    private static readonly int[][] directions = [[0, 1], [0, -1], [1, 0], [-1, 0]];
+    public static int OrangesRotting(int[][] grid)
+    {
+        Queue<(int x, int y)> queue = new();
+
+        int m = grid.Length;
+        int n = grid[0].Length;
+
+        bool[,] visited = new bool[m, n];
+
+        int freshCount = 0;
+
+        // search rotten one
+
+        for (int i = 0; i < m; i++)
+        {
+            for (int j = 0; j < n; j++)
+            {
+                int val = grid[i][j];
+                if (val is 1)
+                {
+                    freshCount++;
+                }
+                else if (val is 2)
+                {
+                    queue.Enqueue((x: j, y: i));
+                }
+            }
+        }
+
+        int minute = 0;
+        while (queue.Count > 0)
+        {
+            int batchSize = queue.Count;
+
+            for (int i = 0; i < batchSize; i++)
+            {
+                var current = queue.Dequeue();
+
+                if (visited[current.y, current.x]) continue;
+
+                visited[current.y, current.x] = true;
+
+                foreach (int[] dir in directions)
+                {
+                    int nextY = current.y + dir[0];
+                    int nextX = current.x + dir[1];
+
+                    if (nextY >= 0
+                        && nextY < m
+                        && nextX >= 0
+                        && nextX < n
+                        && visited[nextY, nextX] == false
+                        && grid[nextY][nextX] is 1)
+                    {
+                        freshCount--;
+                        grid[nextY][nextX] = 2;
+                        queue.Enqueue((x: nextX, y: nextY));
+                    }
+                }
+
+            }
+            if (queue.Count > 0)
+                minute++;
+        }
+
+        return freshCount == 0 ? minute : -1;
+    }
+}

--- a/solutions/RottingOranges.cs
+++ b/solutions/RottingOranges.cs
@@ -25,9 +25,6 @@ public class RottingOranges
 
         int m = grid.Length;
         int n = grid[0].Length;
-
-        bool[,] visited = new bool[m, n];
-
         int freshCount = 0;
 
         // search rotten one
@@ -57,21 +54,12 @@ public class RottingOranges
             {
                 var current = queue.Dequeue();
 
-                if (visited[current.y, current.x]) continue;
-
-                visited[current.y, current.x] = true;
-
                 foreach (int[] dir in directions)
                 {
                     int nextY = current.y + dir[0];
                     int nextX = current.x + dir[1];
-
-                    if (nextY >= 0
-                        && nextY < m
-                        && nextX >= 0
-                        && nextX < n
-                        && visited[nextY, nextX] == false
-                        && grid[nextY][nextX] is 1)
+                    
+                    if (nextY >= 0 && nextY < m && nextX >= 0 && nextX < n && grid[nextY][nextX] == 1)
                     {
                         freshCount--;
                         grid[nextY][nextX] = 2;


### PR DESCRIPTION
This pull request introduces new solutions for two graph traversal problems, `NearestExitFromEntranceInMaze` and `RottingOranges`, and updates the `Program.cs` file to demonstrate the usage of these solutions. The changes include implementing algorithms for both problems, refactoring one of the solutions for improved readability, and adding example calls to test the implementations.

### New Problem Solutions:

* **`NearestExitFromEntranceInMaze` Implementation**:
  - Added a class `NearestExitFromEntranceInMaze` with two methods: `NearestExit` and `NearestExitRefactored`. Both methods solve the problem of finding the nearest exit in a maze using breadth-first search (BFS). The refactored version improves readability by using a `directions` array for movement and marking visited cells earlier.

* **`RottingOranges` Implementation**:
  - Added a class `RottingOranges` with a method `OrangesRotting`. This method uses BFS to calculate the minimum time required for all fresh oranges to rot, or returns `-1` if it's impossible. It includes constraints handling and efficient traversal using a queue.

### Updates to `Program.cs`:

* **Test Cases for `NearestExitFromEntranceInMaze`**:
  - Removed previous example code for `FindCenterOfStarGraph` and added multiple commented-out test cases for `NearestExitFromEntranceInMaze`. Enabled one test case (`reuslt4`) to demonstrate the solution.